### PR TITLE
Updated the Github Actions to deploy a test version of the site to a …

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -65,3 +65,24 @@ jobs:
       - id: deployment
         name: Deploy to GitHub Pages
         uses: actions/deploy-pages@v2
+
+  deploy_staging:
+    name: Deploy to Staging
+    if: github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    needs: build
+
+    permissions:
+      pages: write
+      id-token: write
+
+    environment:
+      name: staging
+      url: ${{ steps.staging_deployment.outputs.page_url }}
+
+    steps:
+      - id: staging_deployment
+        name: Deploy to Staging Folder on GitHub Pages
+        uses: actions/deploy-pages@v2
+        with:
+          destination_dir: staging


### PR DESCRIPTION
## Key Changes

- **deploy_staging job**: I made this new job making sure it handles the deployment of any branch to the `/staging` folder. It's triggered by the `workflow_dispatch` event, meaning it can be run manually from the GitHub Actions tab.

- **destination_dir: staging**: In the `deploy_staging` step, I set the `destination_dir` option to `staging`, so the files will be deployed to the `/staging` folder on GitHub Pages.

- **Manual trigger**: Since the `deploy_staging` job runs only on `workflow_dispatch`, it won’t interfere with regular deployments to the main branch.

**How to Trigger:**

From research, i discovered that the workflow can be manually triggered by navigating to the **Actions** tab on GitHub, selecting the appropriate workflow, and running it for a desired branch. This will deploy the changes to a `/staging` folder on GitHub Pages.

This setup allows you to have two separate deployments: one for the main branch (direct deployment to GitHub Pages) and one for testing in a `/staging` folder.